### PR TITLE
CSharp client header problem

### DIFF
--- a/modules/swagger-codegen/src/main/resources/csharp/Configuration.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/Configuration.mustache
@@ -158,7 +158,22 @@ namespace {{packageName}}.Client
         /// <returns></returns>
         public void AddDefaultHeader(string key, string value)
         {
+            if (_defaultHeaderMap.ContainsKey(key))
+                _defaultHeaderMap.Remove(key);
             _defaultHeaderMap.Add(key, value);
+        }
+
+        /// <summary>
+        /// Add Api Key.
+        /// </summary>
+        /// <param name="key">Api Key name.</param>
+        /// <param name="value">Api Key value.</param>
+        /// <returns></returns>
+        public void AddApiKeyPrefix(string key, string value)
+        {
+            if (ApiKeyPrefix.ContainsKey(key))
+                ApiKeyPrefix.Remove(key);
+            ApiKeyPrefix.Add(key, value);
         }
 
         /// <summary>


### PR DESCRIPTION
CSharp client may cause an error adding an header because the header
list is static.
Added a check and a function tu set up the ApiKey